### PR TITLE
modified docker compose images to switch to mariadb from mysql

### DIFF
--- a/docker-compose-nodejs.yml
+++ b/docker-compose-nodejs.yml
@@ -81,7 +81,7 @@ services:
       - code-network
     restart: always
   db:
-    image: mysql:5
+    image: mariadb:10.11.3
     env_file: .env
     environment:
       TZ: UTC

--- a/docker-compose-standard.yml
+++ b/docker-compose-standard.yml
@@ -68,7 +68,7 @@ services:
           - code-network
         restart: always
     db:
-      image: mysql:5
+      image: mariadb: 10.11.3
       env_file: .env
       environment:
         TZ: UTC


### PR DESCRIPTION
modified docker compose images to switch to mariadb from mysql, as mysql docker image does not support arm processors and I'm working on a m1 based hardware